### PR TITLE
Trade API fix

### DIFF
--- a/lib/btce.rb
+++ b/lib/btce.rb
@@ -244,8 +244,8 @@ module Btce
       def trade_api_call(method, extra)
         params = {"method" => method, "nonce" => nonce}
         if ! extra.empty?
-          extra.each do |a|
-            params[a.to_s] = a
+          extra.each do |k,v|
+            params[k.to_s] = v
           end
         end
         signed = sign params


### PR DESCRIPTION
Trade API was not working for me due to the way key value pairs in the "extras" argument were being stored in the params hash. This fixes it and has been live tested to work.
