### PR TITLE
Allow calls every millisecond instead of every second

### DIFF
--- a/btce.gemspec
+++ b/btce.gemspec
@@ -34,8 +34,8 @@
 
 Gem::Specification.new do |s|
   s.name = 'btce'
-  s.version = '0.1.5'
-  s.date = '2013-04-28'
+  s.version = '0.1.6'
+  s.date = '2013-05-06'
   s.summary = "A simple library to interface with the API for btc-e.com in Ruby."
   s.description = "A simple library to interface with the API for btc-e.com in Ruby."
   s.authors = ['Christopher Mark Gore']

--- a/lib/btce.rb
+++ b/lib/btce.rb
@@ -261,10 +261,8 @@ module Btce
       end
       
       def nonce
-        while result = Time.now.to_i and @last_nonce and @last_nonce >= result
-          sleep 1
-        end
-        return @last_nonce = result
+	sleep 0.001
+	(Time.now.to_f * 100_000_000).to_i
       end
       private :nonce
 


### PR DESCRIPTION
This speeds up the API and is still safe against nonce collisions.
